### PR TITLE
Fixed typo in understanding-di docs section

### DIFF
--- a/doc/understanding-di.md
+++ b/doc/understanding-di.md
@@ -164,7 +164,7 @@ $storeService = $container->get('StoreService');
 and configure which GeolocationService PHP-DI should automatically inject in StoreService through configuration:
 
 ```php
-$container->set('GeolocationService', \DI\create('GoogleMaps'));
+$container->set('StoreService', \DI\create('GoogleMaps'));
 ```
 
 If you change your mind, there's just one line of configuration to change now.


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

Fixed typo in documentation (the edit is self-explanatory).